### PR TITLE
[TASK] Exclude .ddev directory from dist archives and packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *                            text=auto
+/.ddev                       export-ignore
 /.github                     export-ignore
 /Tests                       export-ignore
 /.crowdin.yaml               export-ignore

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 return [
     'directories' => [
         '.build',
+        '.ddev',
         '.git',
         '.github',
         'bin',


### PR DESCRIPTION
The `.ddev` directory must not be present in dist archives and packages since it's targeted for extension development only.