### PR TITLE
[BUGFIX] Consider site's base url for sitemaps cache identifier

### DIFF
--- a/Tests/Functional/EventListener/SiteConfigurationListenerTest.php
+++ b/Tests/Functional/EventListener/SiteConfigurationListenerTest.php
@@ -103,7 +103,7 @@ final class SiteConfigurationListenerTest extends TestingFramework\Core\Function
 
         ($this->subject)($event);
 
-        self::assertFalse($this->cache->has('foo'));
+        self::assertFalse($this->cache->has('foo_0_da39a3ee5e6b4b0d3255bfef95601890afd80709'));
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR changes the way how located sitemaps are cached. Prior to this change, it was possible that a cache entry reflects another state of a site, if any base variants are configured. This is due to the fact that the cache identifier only consisted of the site's identifier, leaving any other configuration outside.

With this PR, the base url is now part of the cache identifier. In addition, sitemaps are no longer cached on a per-site basis, but rather on a site/site language combination, making it easier to fetch and manipulate cache entries.

Related: eliashaeussler/typo3-warming#535