### PR TITLE
[BUGFIX] Use GET method to determine validity of XML sitemap

### DIFF
--- a/Classes/Sitemap/SitemapLocator.php
+++ b/Classes/Sitemap/SitemapLocator.php
@@ -112,7 +112,7 @@ final class SitemapLocator
     {
         // Check if sitemap is accessible
         try {
-            $response = $this->requestFactory->request((string)$sitemap->getUri(), 'HEAD');
+            $response = $this->requestFactory->request((string)$sitemap->getUri());
             $isValid = $response->getStatusCode() < 400;
         } catch (\Exception $exception) {
             $response = $exception instanceof RequestException ? $exception->getResponse() : null;


### PR DESCRIPTION
This PR changes the `SitemapLocator::isValidSitemap()` method to perform `GET` requests instead of `HEAD` requests. This makes the whole validation step more realistic and aims to avoid curl issues that may not occur in real-world scenarios.

Resolves: #89
Related: eliashaeussler/typo3-warming#137