### PR TITLE
Avoid PHP 8.4 deprecations

### DIFF
--- a/Classes/Cache/SitemapsCache.php
+++ b/Classes/Cache/SitemapsCache.php
@@ -43,7 +43,7 @@ final class SitemapsCache
      */
     public function get(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): array {
         $cacheIdentifier = $this->calculateCacheIdentifier($site, $siteLanguage);
         $cacheData = $this->readCache($cacheIdentifier);
@@ -109,7 +109,7 @@ final class SitemapsCache
      */
     public function remove(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): void {
         $cacheIdentifier = $this->calculateCacheIdentifier($site, $siteLanguage);
 
@@ -145,7 +145,7 @@ final class SitemapsCache
 
     private function calculateCacheIdentifier(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): string {
         if ($siteLanguage === null) {
             $siteLanguage = $site->getDefaultLanguage();

--- a/Classes/Form/Element/XmlSitemapLocationElement.php
+++ b/Classes/Form/Element/XmlSitemapLocationElement.php
@@ -56,7 +56,7 @@ final class XmlSitemapLocationElement extends Backend\Form\Element\AbstractFormE
     /**
      * @todo Use DI once support for TYPO3 v12 is dropped
      */
-    public function __construct(Backend\Form\NodeFactory $nodeFactory = null, array $data = [])
+    public function __construct(?Backend\Form\NodeFactory $nodeFactory = null, array $data = [])
     {
         if ((new Core\Information\Typo3Version())->getMajorVersion() < 13) {
             parent::__construct($nodeFactory, $data);

--- a/Classes/Sitemap/Provider/PageTypeProvider.php
+++ b/Classes/Sitemap/Provider/PageTypeProvider.php
@@ -46,7 +46,7 @@ final class PageTypeProvider implements Provider
 
     public function get(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): array {
         // Early return if EXT:seo is not installed
         if (!Core\Utility\ExtensionManagementUtility::isLoaded('seo')) {

--- a/Classes/Sitemap/SitemapLocator.php
+++ b/Classes/Sitemap/SitemapLocator.php
@@ -61,7 +61,7 @@ final class SitemapLocator
      */
     public function locateBySite(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): array {
         // Get sitemaps from cache
         if (($sitemaps = $this->cache->get($site, $siteLanguage)) !== []) {
@@ -131,7 +131,7 @@ final class SitemapLocator
      */
     private function resolveSitemaps(
         Core\Site\Entity\Site $site,
-        Core\Site\Entity\SiteLanguage $siteLanguage = null,
+        ?Core\Site\Entity\SiteLanguage $siteLanguage = null,
     ): array {
         foreach ($this->providers as $provider) {
             if (($sitemaps = $provider->get($site, $siteLanguage)) !== []) {


### PR DESCRIPTION
Fixes the following deprecation messages:

    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Cache\SitemapsCache::get(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Cache/SitemapsCache.php on line 44
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Cache\SitemapsCache::remove(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Cache/SitemapsCache.php on line 110
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Cache\SitemapsCache::calculateCacheIdentifier(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Cache/SitemapsCache.php on line 146
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Form\Element\XmlSitemapLocationElement::__construct(): Implicitly marking parameter $nodeFactory as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Form/Element/XmlSitemapLocationElement.php on line 59
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Sitemap\Provider\PageTypeProvider::get(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Sitemap/Provider/PageTypeProvider.php on line 47
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Sitemap\SitemapLocator::locateBySite(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Sitemap/SitemapLocator.php on line 62
    PHP Deprecated:  EliasHaeussler\Typo3SitemapLocator\Sitemap\SitemapLocator::resolveSitemaps(): Implicitly marking parameter $siteLanguage as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/eliashaeussler/typo3-sitemap-locator/Classes/Sitemap/SitemapLocator.php on line 132