### PR TITLE
[BUGFIX] Avoid deprecations with TYPO3 v14 in classic mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
 	},
 	"extra": {
 		"typo3/cms": {
+			"Package": {
+				"providesPackages": {}
+			},
 			"extension-key": "sitemap_locator",
 			"web-dir": ".Build/web"
 		},

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
 				"providesPackages": {}
 			},
 			"extension-key": "sitemap_locator",
+			"version": "1.3.2",
 			"web-dir": ".Build/web"
 		},
 		"version-bumper": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63312a27ce4df2c47d20396f7c504f34",
+    "content-hash": "cf28eccbad0ffce29e3f060fbdb733ba",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae4f88e3723d6a4d2370ef89b41dd342",
+    "content-hash": "63312a27ce4df2c47d20396f7c504f34",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension metadata to explicitly identify version 1.3.2.
  * Added package provisioning metadata for improved compatibility with TYPO3 package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->